### PR TITLE
Initial Release of Terraform AWS IAM Role Module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+#### Change Log
+
+[1.0.0] - 2024-12-29
+
+##### Added
+- Initial release of the Terraform AWS IAM Role module.
+- Create IAM roles with specified policies.
+- Attach managed policies to IAM roles.
+- Create instance profiles and associate them with IAM roles.
+- Support for tagging resources.
+- Example usage provided in README.
+- Default tags configuration.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+
+MIT License
+
+Copyright (c) 2024 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,148 @@
-# terraform-aws-iam-role
-◉ 🚩Private Terraform Registry Module - IAM Role with Policy attached / Instance Profile.
+![](https://img.shields.io/github/commit-activity/t/subhamay-bhattacharyya/terraform-aws-iam-role)&nbsp;![](https://img.shields.io/github/last-commit/subhamay-bhattacharyya/terraform-aws-iam-role)&nbsp;![](https://img.shields.io/github/release-date/subhamay-bhattacharyya/terraform-aws-iam-role)&nbsp;![](https://img.shields.io/github/repo-size/subhamay-bhattacharyya/terraform-aws-iam-role)&nbsp;![](https://img.shields.io/github/directory-file-count/subhamay-bhattacharyya/terraform-aws-iam-role)&nbsp;[](https://img.shields.io/github/issues/subhamay-bhattacharyya/terraform-aws-iam-role)&nbsp;![](https://img.shields.io/github/languages/top/subhamay-bhattacharyya/terraform-aws-iam-role)&nbsp;![](https://img.shields.io/github/commit-activity/m/subhamay-bhattacharyya/terraform-aws-iam-role)&nbsp;![](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bsubhamay/14ec97a92b2d05a933f93fc85d3f836c/raw/terraform-aws-iam-role.json?)
+
+## Terraform AWS IAM Role Module
+
+### Usage
+
+* Terraform module to create IAM Role / Policy / EC2 Instance profile.
+* Module source: app.terraform.io/subhamay-bhattacharyya/iam-role/aws
+* Version: 1.0.0
+
+### Required Inputs:
+- `role_name`: The name of the IAM role.
+- `assume_role_policy`: The policy that grants an entity permission to assume the role.
+- `managed_policy_arns`: A list of ARNs of the IAM managed policies to attach to the role.
+- `inline_policies`: A map of inline policies to attach to the role.
+- `tags`: A map of tags to assign to the resources.
+
+### Example Usage:
+
+```hcl
+module "iam_role" {
+  source  = "app.terraform.io/subhamay-bhattacharyya/iam-role/aws"
+  version = "1.0.0"
+
+  project-name                  = var.project-name
+  iam-custom-role-with-policies = local.iam-custom-role-with-policies
+  ec2-instance-profile-name     = var.ec2-instance-profile-name
+  ci-build                      = var.ci-build
+}
+```
+
+#### 
+_Define the policy templates as *.tftpl* files in a seperate directory as follows:_
+
+_DynamoDB Table Access Policy_
+```hcl
+{
+   "Version":"2012-10-17",
+   "Statement":[
+      {
+         "Sid":"AllowWriteAccessToDynamoDBTable",
+         "Effect":"Allow",
+         "Action": ${dynamodb-actions},
+         "Resource": ["${dynamodb-table-arn}"]
+      }
+   ]
+}
+```
+
+_S3 Bucket Policy_
+```hcl
+{
+   "Version":"2012-10-17",
+   "Statement":[
+      {
+         "Sid":"AllowFullAccessToS3Bucket",
+         "Effect":"Allow",
+         "Action": ${s3-bucket-actions},
+         "Resource": ["${s3-bucket-arn}","${s3-bucket-arn}/*"]
+      }
+   ]
+}
+```
+
+_Use local variables to generate the policy document_
+```hcl
+
+locals {
+
+  template-vars = {
+    s3-bucket-arn      = "arn:aws:s3:::${var.s3-bucket-name}"
+    s3-bucket-actions  = jsonencode(var.s3-bucket-actions)
+    dynamodb-table-arn = "arn:aws:dynamodb:${var.aws-region}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodb-table-name}"
+    dynamodb-actions   = jsonencode(var.dynamodb-actions)
+  }
+
+  customer-managed-policies = {
+    "s3-policy"       = jsondecode(templatefile("policy-templates/s3-read-only-policy.tftpl", local.template-vars)),
+    "dynamodb-policy" = jsondecode(templatefile("policy-templates/dynamodb-read-write-policy.tftpl", local.template-vars))
+  }
+
+
+  iam-custom-role-with-policies = {
+    role-name        = "example-role"
+    role-description = "This is an example role."
+    role-path        = "/example/"
+    assume-role-policy-document = {
+      Version = "2012-10-17"
+      Statement = [{
+        Sid    = "AllowEC2Service"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }]
+    }
+    aws-managed-policies = [
+      "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+      "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+    ]
+    customer-managed-policies = local.customer-managed-policies
+  }
+}
+```
+
+##### Default tags
+
+Use local variables to configure the default tags.
+_The default resource tags are implemented using the CI/CD Pipeline. The following mao just refers to it._
+```hcl
+locals {
+  tags = {
+    Environment      = var.environment-name
+    ProjectName      = var.project-name
+    GitHubRepository = var.github-repo
+    GitHubRef        = var.github-ref
+    GitHubURL        = var.github-url
+    GitHubSHA        = var.github-sha
+  }
+}
+```
+#### Note
+
+- To skip the creation of IAM role with AWS managed policy pass `aws-managed-policies = null`
+- To skip the creation of IAM role with AWS customer policy pass `customer-managed-policies = null`
+- To skip the creation of EC2 instance profile pass `ec2-instance-profile-name = null`
+
+## Inputs
+
+| Name                         | Description                                                     | Type   | Default       | Required |
+|-                             |-                                                                |-       |-              |-         |
+| project-name                 | The name of the project                                         | string       | n/a     | yes      |
+| iam-custom-role-with-policies| The policy that grants an entity permission to assume the role  | map(object)  | n/a     | yes      |
+| ec2-instance-profile-name    | The name of EC2 instance profile                                | string       | ""      | yes      |
+| ci-build                     | A string representing the CI build identifier                   | string       | ""      | yes      |
+
+## Outputs
+
+| Name                  | Description                                      |
+|-                      |-                                                 |
+| role-id               | The ID of the IAM role.                          |
+| role-name             | The name of the IAM role.                        |
+| role-arn              | The ARN of the IAM role.                         |
+| policy-arn            | The ARN of the customer managed policy.          |
+| instance-profile-id   | The ID of the instance profile.                  |
+| instance-profile-name | The name of the instance profile.                |
+| instance-profile-arn  | The ARN of the instance profile.                 |

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,15 @@
+#### Version: 1.0.0
+Initial release of the Terraform AWS IAM Role module.
+Version: 1.0.0
+Author: Subhamay Bhattacharyya
+Created: 29-Dec-2024
+Updated: 
+Description: This module creates and manages AWS IAM role / policy and instance profile.
+
+## Features
+- Create IAM roles with specified policies
+- Attach managed policies to IAM roles
+- Create instance profiles and associate them with IAM roles
+- Support for tagging resources
+- Example usage provided in README
+- Default tags configuration

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,17 @@
+/*
+####################################################################################################
+# Terraform IAM Role Module Data Block Configuration
+#
+# Description: This module creates IAM Policy / IAM Role and EC2 Instance Profile.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 29-Dec-2024
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+# AWS Region and Caller Identity
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,77 @@
+/*
+####################################################################################################
+# Terraform IAM Role Module Configuration
+#
+# Description: This module creates IAM Policy / IAM Role and EC2 Instance Profile.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 29-Dec-2024 
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+# Creates an IAM role with the specified name, description, path, and assume role policy.
+# The role name is constructed using the project name, role name, environment name, and CI build identifier.
+# Tags the IAM role with a Name tag constructed using the project name, environment name, and CI build identifier.
+# 
+# Arguments:
+# - name: The name of the IAM role.
+# - description: The description of the IAM role.
+# - path: The path for the IAM role.
+# - assume_role_policy: The policy that grants an entity permission to assume the role.
+# - tags: A map of tags to assign to the IAM role.
+resource "aws_iam_role" "iam_role" {
+  name               = "${var.project-name}-${var.iam-custom-role-with-policies.role-name}${var.ci-build}"
+  description        = var.iam-custom-role-with-policies.role-description
+  path               = var.iam-custom-role-with-policies.role-path
+  assume_role_policy = jsonencode(var.iam-custom-role-with-policies.assume-role-policy-document)
+
+  tags = {
+    Name = "${var.project-name}-${var.iam-custom-role-with-policies.role-name}${var.ci-build}"
+  }
+}
+
+
+# This resource attaches AWS managed policies to an IAM role.
+# 
+# Arguments:
+# - role: The name of the IAM role to attach the policies to.
+# - count: The number of AWS managed policies to attach, determined by the length of the list `var.iam-custom-role-with-policies.aws-managed-policies`.
+# - policy_arn: The ARN of the AWS managed policy to attach, indexed by `count.index` from the list `var.iam-custom-role-with-policies.aws-managed-policies`.
+resource "aws_iam_role_policy_attachment" "aws_managed_policy_attachment" {
+  role = aws_iam_role.iam_role.name
+
+  count      = length(var.iam-custom-role-with-policies.aws-managed-policies)
+  policy_arn = var.iam-custom-role-with-policies.aws-managed-policies[count.index]
+}
+
+
+# This resource block defines an AWS IAM Role Policy.
+# It attaches customer-managed policies to an IAM role.
+# 
+# Arguments:
+# - role: The ID of the IAM role to which the policy will be attached.
+# - for_each: Iterates over the customer-managed policies defined in the variable `iam-custom-role-with-policies`.
+# - name: The name of each policy, derived from the key of the iteration.
+# - policy: The policy document, encoded in JSON format, derived from the value of the iteration.
+resource "aws_iam_role_policy" "customer_managed_policies" {
+  role = aws_iam_role.iam_role.id
+
+  for_each = var.iam-custom-role-with-policies.customer-managed-policies
+  name     = each.key
+  policy   = jsonencode(each.value)
+}
+
+# Creates an IAM instance profile.
+# The instance profile is created only if the `ec2-instance-profile-name` variable is not empty.
+# 
+# Arguments:
+# - count: Determines whether to create the instance profile based on the `ec2-instance-profile-name` variable.
+# - name: The name of the instance profile, constructed using the project name, instance profile name, environment name, and CI build identifier.
+# - role: The IAM role to associate with the instance profile, referenced from the `aws_iam_role` resource.
+resource "aws_iam_instance_profile" "iam_instance_profile" {
+  count = var.ec2-instance-profile-name != "" ? 1 : 0
+  name  = "${var.project-name}-${var.ec2-instance-profile-name}${var.ci-build}"
+  role  = aws_iam_role.iam_role.name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,84 @@
+/*
+####################################################################################################
+# Terraform IAM Role Module Outputs Configuration
+#
+# Description: This module creates IAM Policy / IAM Role and EC2 Instance Profile.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 29-Dec-2024 
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+
+# This output block defines an output variable named "iam-role-id".
+# The description attribute provides a brief explanation of the output, indicating that it represents the IAM Role ID.
+# The value attribute retrieves the ID of the IAM role from the aws_iam_role resource named "iam_role".
+output "iam-role-id" {
+  description = "IAM Role ID"
+  value       = aws_iam_role.iam_role.id
+}
+
+# This output variable provides the name of the IAM Role created by this module.
+# 
+# Attributes:
+# - description: A brief description of the output variable.
+# - value: The name of the IAM Role resource created, referenced from the aws_iam_role resource.
+output "iam-role-name" {
+  description = "IAM Role Name"
+  value       = aws_iam_role.iam_role.name
+}
+
+# This output variable provides the Amazon Resource Name (ARN) of the IAM Role.
+# The ARN is a unique identifier for the IAM Role created by this module.
+# 
+# Attributes:
+# - description: A brief description of the output variable.
+# - value: The ARN of the IAM Role, sourced from the aws_iam_role resource.
+output "iam-role-arn" {
+  description = "IAM Role ARN"
+  value       = aws_iam_role.iam_role.arn
+}
+
+# This output block defines an output variable named "iam-policy-arn".
+# The description attribute provides a brief explanation of the output, indicating that it represents the ARN of an IAM Policy.
+# The value attribute uses the try function to attempt to retrieve the ARNs of customer-managed IAM policies attached to the IAM role.
+# If no customer-managed policies are attached, it returns the string "No Customer Managed Policy Attached".
+output "iam-policy-arn" {
+  description = "IAM Policy ARN"
+  value       = try(aws_iam_role_policy.customer_managed_policies[*].arn, "No Customer Managed Policy Attached")
+}
+
+
+# This output provides the ID of the IAM instance profile.
+# If no instance profile is attached, it returns "No Instance Profile Attached".
+# 
+# Attributes:
+# - description: A brief description of the output.
+# - value: The ID of the IAM instance profile or a fallback message if not attached.
+output "instance-profile-id" {
+  description = "Instance Profile ID"
+  value       = try(aws_iam_instance_profile.iam_instance_profile[0].id, "No Instance Profile Attached")
+}
+
+# This output variable provides the name of the IAM instance profile.
+# If the instance profile is not attached, it returns "No Instance Profile Attached".
+# 
+# Attributes:
+# - description: A brief description of the output variable.
+# - value: The name of the IAM instance profile or a fallback message if not attached.
+output "instance-profile-name" {
+  description = "Instance Profile Name"
+  value       = try(aws_iam_instance_profile.iam_instance_profile[0].name, "No Instance Profile Attached")
+}
+
+# This output provides the ARN of the IAM instance profile.
+# If no instance profile is attached, it returns "No Instance Profile Attached".
+# 
+# Output:
+# - instance-profile-arn: The ARN of the IAM instance profile.
+output "instance-profile-arn" {
+  description = "Instance Profile ARN"
+  value       = try(aws_iam_instance_profile.iam_instance_profile[0].arn, "No Instance Profile Attached")
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,86 @@
+/*
+####################################################################################################
+# Terraform IAM Role Module Variabls Configuration
+#
+# Description: This module creates IAM Policy / IAM Role and EC2 Instance Profile.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 08-Dec-2024 
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+######################################## Project Name ##############################################
+# This variable defines the name of the project.
+# It is a string type variable with a default value of "your-project-name".
+# You can override this default value by providing a different project name.
+variable "project-name" {
+  description = "The name of the project"
+  type        = string
+  default     = "your-project-name"
+}
+
+######################################## IAM Role / Policy #########################################
+
+# This variable defines a map of roles with their respective policies.
+# Each role can have multiple policies, which can be either AWS managed or customer managed.
+# The map key is the role name, and the value is a list of policy ARNs.
+variable "iam-custom-role-with-policies" {
+  type = object({
+    role-name        = string
+    role-description = string
+    role-path        = string
+    assume-role-policy-document = object({
+      Version = string
+      Statement = list(object({
+        Sid       = optional(string, "")
+        Effect    = string
+        Principal = optional(map(string), {}) # Optional Principal added
+        Action    = string
+        Condition = optional(map(any), {}) # Optional Condition added
+      }))
+    })
+    aws-managed-policies      = optional(list(string))
+    customer-managed-policies = optional(map(any))
+  })
+  description = <<EOF
+A map of roles with their respective policies.
+Each role can have multiple policies, which can be either AWS managed or customer managed.
+The map key is the role name, and the value is a list of policy objects.
+Each policy object contains:
+- role-path: The path for the role.
+- assume-role-policy-document: The JSON policy document that grants an entity permission to assume the role.
+  - Principal: An optional map specifying the principal entities allowed to assume the role.
+  - Condition: An optional map specifying conditions for assuming the role.
+- aws-managed-policies: A list of ARNs for AWS managed policies.
+- customer-managed-policies: A map of customer managed policies, where the key is the policy name and the value is an object containing:
+  - policy-name: The name of the custom policy.
+  - policy-document: The policy document for the custom policy, which includes:
+    - Sid: The statement ID.
+    - Effect: The effect of the policy (e.g., Allow or Deny).
+    - Action: A list of actions that are allowed or denied by the policy.
+    - Resource: A list of resources that the policy applies to.
+    - Condition: An optional map of conditions that must be met for the policy to apply.
+EOF
+}
+
+# This variable defines the name of the EC2 instance profile.
+# Type: string
+# Description: The name of the EC2 instance profile
+# Default: ""
+variable "ec2-instance-profile-name" {
+  type        = string
+  description = "The name of the EC2 instance profile"
+  default     = ""
+}
+
+######################################## GitHub ####################################################
+# The CI build string
+# This variable defines the CI build string.
+# It is a string type variable with a default value of an empty string.
+variable "ci-build" {
+  description = "The CI build string"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
### Initial Release of Terraform AWS IAM Role Module (v1.0.0)

#### Summary
This pull request introduces the initial release of the Terraform AWS IAM Role module, version 1.0.0. This module provides the capability to create and manage AWS IAM roles, policies, and instance profiles.

#### Key Features
- Create IAM roles with specified policies
- Attach managed policies to IAM roles
- Create instance profiles and associate them with IAM roles
- Support for tagging resources
- Example usage provided in README
- Default tags configuration

#### Instructions
Please review the added functionalities and provide feedback or approval.

#### Additional Notes
- The module source: `app.terraform.io/subhamay-bhattacharyya/iam-role/aws`
- Example usage and detailed documentation are included in the `README.md`.
- This release includes all necessary configurations and examples for quick integration.
